### PR TITLE
Return error when findOne cannot find anything

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,14 @@ module.exports = function(db, props, opts) {
 
   that.findOne = function(opts, cb) {
     if (typeof opts === 'function') return that.findOne(null, opts)
-  
+
     opts = normalizeQuery(opts)
     opts.limit = 1
 
     return that.find(opts, cb && function(err, results) {
       if (err) return cb(err)
-      cb(null, results.length ? results[0] : null)
+      if (!results.length) return cb(new Error("Index not found for opts:" + opts))
+      else return cb(null, results[0])
     })
   }
 

--- a/test.js
+++ b/test.js
@@ -57,3 +57,31 @@ tape('compound index ranges', function(t) {
     t.end()
   })
 })
+
+tape('find one', function(t) {
+  var index = indexer(memdb(), ['name'])
+
+  index.add({key:'mafintosh', name:'mathias', age:27, country:'denmark'})
+  index.add({key:'watson', name:'thomas', age:30, country:'denmark'})
+  index.add({key:'sorribas', name:'eduardo', age:23, country:'dominican republic'})
+
+  index.findOne('mathias', function(err, keys) {
+    t.notOk(err)
+    t.same(keys, 'mafintosh')
+    t.end()
+  })
+})
+
+tape('find one no result', function(t) {
+  var index = indexer(memdb(), ['name'])
+
+  index.add({key:'mafintosh', name:'mathias', age:27, country:'denmark'})
+  index.add({key:'watson', name:'thomas', age:30, country:'denmark'})
+  index.add({key:'sorribas', name:'eduardo', age:23, country:'dominican republic'})
+
+  index.findOne('unknown', function(err, keys) {
+    t.ok(err)
+    t.ifError(keys)
+    t.end()
+  })
+})


### PR DESCRIPTION
- Include tests for the findOne succeed/fail cases

It seems that an error should be returned to the callback when calling `findOne` for an index key that does not exist. The current implementation returns `null` for `err` and `null` for `account` when `findOne` fails to find a match. This PR fixes that problem, and includes some tests for the issues as well.

I think returning an error is better because it is more explicit than using `null` for `account`, similar to the way a `Key not found` error is returned when a database cannot find a match for a given key.

Please let me know if you have suggestions for me to improve this PR, or feedback in general.
